### PR TITLE
Feat/sync using totally GitHub action

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -1,0 +1,56 @@
+name: 'Docker build'
+description: 'build a docker image'
+inputs:
+  source:
+    description: "image source repository"
+    required: true
+  tag:
+    description: "image tag to build"
+    required: true
+  destination:
+    description: "image destination repository"
+    required: true
+  platforms:
+    description: "image supported platforms"
+    required: false
+    default: "linux/amd64,linux/arm64"
+  module:
+    description: "module name where is defined the image"
+    required: true
+  build_context:
+    description: "docker build context (don't put the modules/MODULE_NAME prefix)"
+    required: true
+  build_args:
+    description: "docker build args string"
+    required: false
+  dry_run:
+    description: "dry run mode enabled"
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    # Add support for more platforms with QEMU
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        platforms: ${{ matrix.image.platforms }}
+    - name: Docker meta for ${{ inputs.source }}:${{ inputs.tag }}
+      id: docker_meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.destination }}
+        tags: |
+          type=raw,value=${{ inputs.tag }}
+    - name: Build ${{ inputs.source }}:${{ inputs.tag }}
+      id: docker_build
+      uses: docker/build-push-action@v6
+      with:
+        context: modules/${{ inputs.module }}/${{ inputs.build_context }}
+        build-args: ${{ inputs.build_args }}
+        tags: ${{ steps.docker_meta.outputs.tags}}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ inputs.dry_run != 'true' }}

--- a/.github/actions/generate-build-sync-image-lists/action.yaml
+++ b/.github/actions/generate-build-sync-image-lists/action.yaml
@@ -1,0 +1,80 @@
+name: 'Generate build and sync image lists'
+description: 'For the module in input, generate a list of image to build and a list of image to sync'
+inputs:
+  modules:
+    description: 'module list'
+    required: true
+outputs:
+  image_to_build:
+    description: 'JSON list of image to build'
+    value: ${{ steps.generate_lists.outputs.image_to_build }}
+  image_to_sync:
+    description: 'JSON list of image to sync'
+    value: ${{ steps.generate_lists.outputs.image_to_sync }}
+runs:
+  using: 'composite'
+  steps:
+    - name: generate build and sync image lists
+      id: generate_lists
+      shell: bash
+      run: |-
+        for module in ${{ inputs.modules }}
+        do
+          yq eval ".images |= map(. + {\"module\": \"$module\"})" modules/${module}/images.yml | yq eval '.images' >> all_images.yml
+        done
+                        
+        # Ensure that the module variable is passed correctly to jq using --arg
+        IMAGE_TO_BUILD_JSON=$(yq eval all_images.yml -ojson | jq -c '[.[] |
+          select(.build != null) |
+          .tag[] as $tag |
+          {
+            source: .source,
+            tag: $tag,
+            destination: (
+              .destinations | map("  \(. )") | join("\n")
+            ),
+            platforms: (
+              if .["multi-arch"] // true then
+                "linux/amd64,linux/arm64"
+              else
+                "linux/amd64"
+              end
+            ),
+            build: {
+              args: (
+                if .build.args == null then
+                  ""
+                else
+                  (.build.args | map("  \(.name)=\(.value)") | join("\n"))
+                end
+              ),
+              context: .build.context
+            },
+            module: .module
+          }
+        ]')
+
+        # Process images.yml to create IMAGE_TO_SYNC_JSON
+        IMAGE_TO_SYNC_JSON=$(yq eval all_images.yml -ojson | jq -c '[.[] |
+            select(.build == null) |
+            .tag[] as $t |
+            .destinations[] as $d |
+            {
+              "source": .source,
+              "tag": $t,
+              "destination": $d,
+              "multi-arch": (
+                if .["multi-arch"] == null
+                then
+                  true
+                else
+                  .["multi-arch"]
+                end
+              )
+            }
+          ]'
+        )
+        
+        # Set the output variables for subsequent steps
+        echo "image_to_build=$IMAGE_TO_BUILD_JSON" >> $GITHUB_OUTPUT
+        echo "image_to_sync=$IMAGE_TO_SYNC_JSON" >> $GITHUB_OUTPUT

--- a/.github/actions/get-modules/action.yaml
+++ b/.github/actions/get-modules/action.yaml
@@ -1,0 +1,16 @@
+name: 'Get available modules to sync'
+description: 'Analyze the repository "modules" directory and return a list as string'
+outputs:
+  modules:
+    value: ${{ steps.set_output.outputs.modules }}
+    description: 'JSON list of modules to sync'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@master
+    - id: set_output
+      shell: bash
+      run: |
+        MODULES=$(find modules -mindepth 1 -maxdepth 1 -type d  | cut -d/ -f2 | xargs echo -n)
+        MODULES_JSON=\'[\"${MODULES//[$'\r\n']/\",\"}\"]\'
+        echo "modules=${MODULES}" >> $GITHUB_OUTPUT

--- a/.github/actions/skopeo-sync/action.yaml
+++ b/.github/actions/skopeo-sync/action.yaml
@@ -1,0 +1,199 @@
+name: 'skopeo sync container images'
+description: 'sync docker image to another registry'
+inputs:
+  source:
+    description: "image source repository"
+    required: true
+  tag:
+    description: "image tag to sync"
+    required: true
+  destination:
+    description: "image destination repository"
+    required: true
+  multi-arch:
+    description: "want to sync multiple archictecture"
+    required: true
+    default: true
+  registry_auth_file:
+    description: "skopeo REGISTRY_AUTH_FILE env var value"
+    required: true
+    default: '/tmp/auth.json'
+  dry_run:
+    description: "dry run mode enabled"
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - name: check if multi arch ${{ inputs.source }}:${{ inputs.tag }} is in sync with ${{ inputs.destination }}
+      if: inputs.multi-arch
+      id: multi_arch_need_sync
+      shell: bash
+      env:
+        REGISTRY_AUTH_FILE: ${{ inputs.registry_auth_file }}
+      run: |
+        #!/bin/bash
+        curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/local/bin/jq
+        chmod +x /usr/local/bin/jq
+
+        set +e
+        # Fetch source and target image details
+        source_manifest=$(skopeo inspect --raw docker://${{ inputs.source }}:${{ inputs.tag }} 2>&1)
+        if [[ $? -ne 0 ]]; then
+            echo "Error can't get info about ${{ inputs.source }}:${{ inputs.tag }}. Exit!"
+            exit 255
+        fi
+
+        target_manifest=$(skopeo inspect --raw docker://${{ inputs.destination }}:${{ inputs.tag }} 2> /dev/null)
+        if [[ $? -ne 0 ]]; then
+            echo "Error can't get info about ${{ inputs.destination }}:${{ inputs.tag }}."
+        fi
+        set -e
+
+        NEED_SYNC=false
+        source_digest=
+        target_digest=
+        source_schema_version=$(echo "$source_manifest" | jq -r '.schemaVersion')
+        target_schema_version=$(echo "$target_manifest" | jq -r '.schemaVersion')
+        if [ "${source_schema_version}" = "1" ] && [ "${target_schema_version}" = "1" ]
+        then
+          source_digest=$(echo "$source_manifest" | jq -c '.fsLayers')
+          target_digest=$(echo "$target_manifest" | jq -c '.fsLayers' 2> /dev/null)
+        elif [ "${source_schema_version}" = "2" ] && [ "${target_schema_version}" = "2" ]
+        then 
+          source_media_type=$(echo "$source_manifest" | jq -r '.mediaType')
+          target_media_type=$(echo "$target_manifest" | jq -r '.mediaType')
+            
+          if [ "${source_media_type}" != "${target_media_type}" ]
+          then
+            echo "WARN[${{ inputs.source }}:${{ inputs.tag }}]: source and target manifest type diverge. Sync is required"
+            NEED_SYNC=true
+          else
+            case "$source_media_type" in
+              "application/vnd.docker.distribution.manifest.list.v2+json")
+                source_digest=$(echo "$source_manifest" | jq -c '[.manifests[].digest]')
+                target_digest=$(echo "$target_manifest" | jq -c '[.manifests[].digest]' 2> /dev/null)
+                ;;
+              "application/vnd.oci.image.index.v1+json")
+                source_digest=$(echo "$source_manifest" | jq -c '[.manifests[].digest]')
+                target_digest=$(echo "$target_manifest" | jq -c '[.manifests[].digest]' 2> /dev/null)
+                ;;
+              "application/vnd.docker.distribution.manifest.v2+json")
+                source_digest=$(echo "$source_manifest" | jq -c '[.layers[].digest]')
+                target_digest=$(echo "$target_manifest" | jq -c '[.layers[].digest]' 2> /dev/null)
+                ;;
+              "null")
+                source_digest=$(echo "$source_manifest" | jq -c '[.manifests[].digest]')
+                target_digest=$(echo "$target_manifest" | jq -c '[.manifests[].digest]' 2> /dev/null)
+                ;;
+              *)
+                echo "Invalid media type: $source_media_type"
+                exit 2
+              ;;
+            esac
+          fi
+        else
+          echo "Invalid schema version -> source=$source_schema_version target=$target_schema_version"
+          NEED_SYNC=true
+        fi
+      
+        if [[ $NEED_SYNC = "false" ]]
+        then
+          match=$(jq -n \
+            --argjson source_digest "${source_digest}" \
+            --argjson target_digest "${target_digest}" \
+            '($target_digest == $source_digest)')
+        
+          if [[ "$match" == true ]]; then
+            NEED_SYNC=false
+            echo "SUCCESS[${{ inputs.destination }}:${{ inputs.tag }}] in sync with ${{ inputs.source }}:${{ inputs.tag }}. No other actions are required."
+          else
+            echo "WARN[${{ inputs.destination }}:${{ inputs.tag }}] not in sync with ${{ inputs.source }}:${{ inputs.tag }}"
+            diffs=$(jq -n \
+              --argjson source "${source_digest}" \
+              --argjson target "${target_digest}" \
+              '($source | to_entries) - ($target | to_entries)')
+            echo "diffs are: $diffs"
+          fi
+        fi
+        
+        # Output the result
+        echo "NEED_SYNC=${NEED_SYNC}" >> $GITHUB_OUTPUT
+    - name: check if ${{ inputs.source }}:${{ inputs.tag }} is in sync with ${{ inputs.destination }}
+      if: inputs.multi-arch == false
+      id: need_sync
+      shell: bash
+      env:
+        REGISTRY_AUTH_FILE: ${{ inputs.registry_auth_file }}
+      run: |
+        #!/bin/bash
+        curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/local/bin/jq
+        chmod +x /usr/local/bin/jq
+
+        set +e
+        # Fetch source and target image details
+        source_manifest=$(skopeo inspect \
+          --override-os linux \
+          --override-arch amd64 \
+          docker://${{ inputs.source }}:${{ inputs.tag }} 2>&1)
+        if [[ $? -ne 0 ]]; then
+            echo "Error can't get info about ${{ inputs.source }}:${{ inputs.tag }}. Exit!"
+            exit 255
+        fi
+
+        target_manifest=$(skopeo inspect \
+          --override-os linux \
+          --override-arch amd64 \
+          docker://${{ inputs.destination }}:${{ inputs.tag }} 2> /dev/null)
+        if [[ $? -ne 0 ]]; then
+            echo "Error can't get info about ${{ inputs.destination }}:${{ inputs.tag }}."
+        fi
+        set -e
+
+        set -x
+        source_digest=$(echo "$source_manifest" | jq -c '.Layers')
+        target_digest=$(echo "$target_manifest" | jq -c '.Layers' 2> /dev/null)
+
+        NEED_SYNC=true
+        match=$(echo "${target_digest}" | jq \
+          --argjson source_digest "${source_digest}" \
+          '. == $source_digest')
+
+        if [[ "$match" == true ]]; then
+          NEED_SYNC=false
+          echo "${{ inputs.destination }}:${{ inputs.tag }} is in sync with ${{ inputs.source }}:${{ inputs.tag }}".
+          echo "No other actions are required."
+        else
+          echo "${{ inputs.destination }}:${{ inputs.tag }} is not in sync with ${{ inputs.source }}:${{ inputs.tag }}"
+        fi
+
+        # Output the result
+        echo "NEED_SYNC=${NEED_SYNC}" >> $GITHUB_OUTPUT
+    - name: sync multi arch ${{ inputs.source }}:${{ inputs.tag }} to ${{ inputs.destination }}
+      if: inputs.multi-arch && steps.multi_arch_need_sync.outputs.NEED_SYNC == 'true' && inputs.dry_run != 'true'
+      id: multi_arch_sync
+      shell: bash
+      env:
+        REGISTRY_AUTH_FILE: ${{ inputs.registry_auth_file }}
+      run: |
+        set -e
+        skopeo copy --preserve-digests --multi-arch all \
+          docker://${{ inputs.source }}:${{ inputs.tag }} \
+          docker://${{ inputs.destination }}:${{ inputs.tag }}
+    - name: sync ${{ inputs.source }}:${{ inputs.tag }} to ${{ inputs.destination }}
+      if: inputs.multi-arch == false && steps.need_sync.outputs.NEED_SYNC == 'true' && inputs.dry_run != 'true'
+      id: sync
+      shell: bash
+      env:
+        REGISTRY_AUTH_FILE: ${{ inputs.registry_auth_file }}
+      run: |
+        set -e
+        skopeo copy --preserve-digests \
+          docker://${{ inputs.source }}:${{ inputs.tag }} \
+          docker://${{ inputs.destination }}:${{ inputs.tag }}
+    - name: print warning executing in dry run
+      if: inputs.dry_run && (steps.multi_arch_need_sync.outputs.NEED_SYNC == 'true' ||steps.need_sync.outputs.NEED_SYNC == 'true')
+      shell: bash
+      run: |
+        echo "WARN[${{ inputs.source }}:${{ inputs.tag }}]: dry run is enabled and no sync will be executed"
+        exit 100

--- a/.github/workflows/dry.yml
+++ b/.github/workflows/dry.yml
@@ -4,52 +4,966 @@ on:
   push:
     paths:
       - '.github/workflows/dry.yml'
-      - '.github/workflows/sync.yml'
+      - '.github/actions/**'
       - 'modules/**'
       - '!README.md'
-      - '!single_sync.sh'
-      - '!single_sync_v2.sh'
-      - 'single_sync_v3.sh'
+
+env:
+  DRY_RUN: true
 
 jobs:
-  fetch_modules_to_sync:
-    runs-on: ubuntu-latest
+  get_modules:
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@master
-      - name: Set output
-        id: set_output
-        run: |
-          MODULES_TO_SYNC_JSON=$(find modules -type d -mindepth 1 -maxdepth 1 | cut -d/ -f2 | sort | jq -R | jq -cs . )
-          echo "MODULES_TO_SYNC_JSON=${MODULES_TO_SYNC_JSON}" >> $GITHUB_OUTPUT
+      - name: fetch available modules
+        uses: ./.github/actions/get-modules
+        id: get_modules_as_string
     outputs:
-      modules_to_sync: ${{ steps.set_output.outputs.MODULES_TO_SYNC_JSON }}
-  sync:
-    runs-on: ubuntu-latest
-    needs: fetch_modules_to_sync
+      modules: ${{ steps.get_modules_as_string.outputs.modules }}
+  build_list:
+    runs-on: ubuntu-24.04
+    needs: get_modules
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD image build list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: ${{ needs.get_modules.outputs.modules }}
+    outputs:
+      image_to_build: ${{ steps.generate_image_lists.outputs.image_to_build }}
+  build:
+    runs-on: ubuntu-24.04
+    needs:
+      - build_list
     strategy:
       fail-fast: false
       matrix:
-        module: ${{ fromJson(needs.fetch_modules_to_sync.outputs.modules_to_sync) }}
+        image: ${{ fromJson(needs.build_list.outputs.image_to_build) }}
     steps:
       - uses: actions/checkout@master
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_TEMP }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD_TEMP }}
       - name: Login to SIGHUP new Registry
         uses: docker/login-action@v3
         with:
           registry: registry.sighup.io
           username: ${{ secrets.SIGHUP_REGISTRY_USERNAME }}
           password: ${{ secrets.SIGHUP_REGISTRY_PASSWORD }}
-      - name: Install yq
+      - name: setup docker build for ${{ matrix.image.destination }}:${{ matrix.image.tag }}
+        uses: ./.github/actions/docker-build
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          platforms: ${{ matrix.image.platforms }}
+          module: ${{ matrix.image.module }}
+          build_context: ${{ matrix.image.build.context }}
+          build_args: ${{ matrix.image.build.args }}
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ############ AUTH ############
+  ##############################
+  auth_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD auth image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'auth'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_auth:
+    runs-on: ubuntu-24.04
+    needs:
+      - auth_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.auth_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
         run: |
-          sudo apt-get update && sudo apt-get install -yqq wget
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.19.1/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-      - name: Iterate
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ###############################
+  ############# AWS #############
+  ###############################
+  aws_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD aws image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'aws'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_aws:
+    runs-on: ubuntu-24.04
+    needs:
+      - aws_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.aws_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
         run: |
-          yq --version
-          docker run --rm quay.io/skopeo/stable:v1.13 --version
-          ./single_sync_v3.sh modules/${{ matrix.module }}/images.yml true
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ############# DR #############
+  ##############################
+  dr_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD dr image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'dr'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_dr:
+    runs-on: ubuntu-24.04
+    needs:
+      - dr_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.dr_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ########### EXTRA ############
+  ##############################
+  extra_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD extra image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'extra'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_extra:
+    runs-on: ubuntu-24.04
+    needs:
+      - extra_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.extra_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ########### INGRESS ##########
+  ##############################
+  ingress_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD ingress image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'ingress'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_ingress:
+    runs-on: ubuntu-24.04
+    needs:
+      - ingress_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.ingress_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ########### KAFKA ##########
+  ##############################
+  kafka_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD kafka image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'kafka'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_kafka:
+    runs-on: ubuntu-24.04
+    needs:
+      - kafka_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.kafka_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### KEYCLOACK ##########
+  ##############################
+  keycloak_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD keycloak image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'keycloak'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_keycloak:
+    runs-on: ubuntu-24.04
+    needs:
+      - keycloak_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.keycloak_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### KONG ##########
+  ##############################
+  kong_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD kong image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'kong'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_kong:
+    runs-on: ubuntu-24.04
+    needs:
+      - kong_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.kong_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### KUMA ##########
+  ##############################
+  kuma_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD kuma image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'kuma'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_kuma:
+    runs-on: ubuntu-24.04
+    needs:
+      - kuma_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.kuma_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### logging ##########
+  ##############################
+  logging_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD logging image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'logging'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_logging:
+    runs-on: ubuntu-24.04
+    needs:
+      - logging_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.logging_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### monitoring ##########
+  ##############################
+  monitoring_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD monitoring image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'monitoring'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_monitoring:
+    runs-on: ubuntu-24.04
+    needs:
+      - monitoring_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.monitoring_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### networking ##########
+  ##############################
+  networking_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD networking image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'networking'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_networking:
+    runs-on: ubuntu-24.04
+    needs:
+      - networking_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.networking_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### on-premise ##########
+  ##############################
+  onprem_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD on-premise image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'on-premises'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_onprem:
+    runs-on: ubuntu-24.04
+    needs:
+      - onprem_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.onprem_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### opa ##########
+  ##############################
+  opa_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD opa image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'opa'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_opa:
+    runs-on: ubuntu-24.04
+    needs:
+      - opa_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.opa_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### postgresql ##########
+  ##############################
+  postgresql_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD postgresql image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'postgresql'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_postgresql:
+    runs-on: ubuntu-24.04
+    needs:
+      - postgresql_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.postgresql_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### redis ##########
+  ##############################
+  redis_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD redis image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'redis'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_redis:
+    runs-on: ubuntu-24.04
+    needs:
+      - redis_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.redis_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### registry ##########
+  ##############################
+  registry_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD registry image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'registry'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_registry:
+    runs-on: ubuntu-24.04
+    needs:
+      - registry_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.registry_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### service-mesh ##########
+  ##############################
+  service-mesh_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD service-mesh image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'service-mesh'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_service-mesh:
+    runs-on: ubuntu-24.04
+    needs:
+      - service-mesh_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.service-mesh_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### storage ##########
+  ##############################
+  storage_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD storage image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'storage'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_storage:
+    runs-on: ubuntu-24.04
+    needs:
+      - storage_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.storage_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### tracing ##########
+  ##############################
+  tracing_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD tracing image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'tracing'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_tracing:
+    runs-on: ubuntu-24.04
+    needs:
+      - tracing_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.tracing_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### vault ##########
+  ##############################
+  vault_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD vault image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'vault'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_vault:
+    runs-on: ubuntu-24.04
+    needs:
+      - vault_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.vault_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}
+  ##############################
+  ######### vsphere ##########
+  ##############################
+  vsphere_list:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: generate KFD vsphere image sync list
+        id: generate_image_lists
+        uses: ./.github/actions/generate-build-sync-image-lists
+        with:
+          modules: 'vsphere'
+    outputs:
+      image_to_sync: ${{ steps.generate_image_lists.outputs.image_to_sync}}
+  sync_vsphere:
+    runs-on: ubuntu-24.04
+    needs:
+      - vsphere_list
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.vsphere_list.outputs.image_to_sync) }}
+    container:
+      image: quay.io/skopeo/stable:v1.16.1
+    steps:
+      - uses: actions/checkout@master
+      - name: Login to registries
+        run: |
+          skopeo login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }} docker.io
+          skopeo login --username ${{ secrets.SIGHUP_REGISTRY_USERNAME }} --password ${{ secrets.SIGHUP_REGISTRY_PASSWORD }} registry.sighup.io
+        env:
+          REGISTRY_AUTH_FILE: /tmp/auth.json
+      - name: sync images with skopeo
+        uses: ./.github/actions/skopeo-sync
+        with:
+          source: ${{ matrix.image.source }}
+          tag: ${{ matrix.image.tag }}
+          destination: ${{ matrix.image.destination }}
+          multi-arch: ${{ matrix.image.multi-arch }}
+          registry_auth_file: /tmp/auth.json
+          dry_run: ${{ env.DRY_RUN }}


### PR DESCRIPTION
WHY

Make more understandable the result of each image sync/build

WHAT

Remove the loop inside the sync script and use a single job for each image. (Due to limit of 256 job in a matrix, there will be a sync job definition for each module