### PR TITLE
Move trivy-adapter-photon-offline build here

### DIFF
--- a/modules/registry/custom/trivy-adapter-photon-offline/Dockerfile
+++ b/modules/registry/custom/trivy-adapter-photon-offline/Dockerfile
@@ -1,0 +1,4 @@
+ARG IMAGETAG="v2.7.0"
+FROM registry.sighup.io/fury/goharbor/trivy-adapter-photon:${IMAGETAG}
+
+RUN trivy image --download-db-only

--- a/modules/registry/images.yml
+++ b/modules/registry/images.yml
@@ -195,8 +195,11 @@ images:
       - registry.sighup.io/fury/goharbor/harbor-exporter
 
   - name: Harbor Trivy Adapter Photon Offline [Fury Kubernetes Registry]
-    source: quay.io/sighup/trivy-adapter-photon-offline
+    source: trivy-adapter-photon-offline
+    build:
+      context: custom/trivy-adapter-photon-offline
     tag:
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/trivy-adapter-photon-offline


### PR DESCRIPTION
This PR moves the build phase of the `registry.sighup.io/fury/goharbor/trivy-adapter-photon-offline` here. 

The old [https://github.com/sighupio/trivy-adapter-photon-offline](repository) is thus not needed anymore.

This makes use of the `IMAGETAG` `--build-arg` that gets automatically injected into the `build` command of each image in order to build a new image for each version of the `trivy-adapter-photon` image.