### PR TITLE
fix(auth): disable gangway

### DIFF
--- a/modules/auth/images.yml
+++ b/modules/auth/images.yml
@@ -37,9 +37,9 @@ images:
     destinations:
       - registry.sighup.io/fury/dexidp/dex
 
-  - name: Gangway [Fury Kubernetes Auth]
-    source: gcr.io/heptio-images/gangway
-    tag:
-      - "v3.2.0"
-    destinations:
-      - registry.sighup.io/fury/heptio-images/gangway
+  # - name: Gangway [Fury Kubernetes Auth]
+  #   source: gcr.io/heptio-images/gangway
+  #   tag:
+  #     - "v3.2.0"
+  #   destinations:
+  #     - registry.sighup.io/fury/heptio-images/gangway

--- a/modules/auth/images.yml
+++ b/modules/auth/images.yml
@@ -37,6 +37,7 @@ images:
     destinations:
       - registry.sighup.io/fury/dexidp/dex
 
+  # Disabled because upstream is gone and makes the sync fail. We've been using our fork Gangplank for several releases anyway.
   # - name: Gangway [Fury Kubernetes Auth]
   #   source: gcr.io/heptio-images/gangway
   #   tag:


### PR DESCRIPTION
Disable gangway's image sync, the upstream image has been removed and this makes the sync job fail:

```
time="2025-05-16T02:37:05Z" level=fatal msg="initializing source docker://gcr.io/heptio-images/gangway:v3.2.0: unable to retrieve auth token: invalid username/password: denied: Project heptio-images has been deleted."
```