### PR TITLE
feat: add kafka images for operator versions 0.42.0, 0.45.0, 0.46.0

### DIFF
--- a/modules/kafka/images.yml
+++ b/modules/kafka/images.yml
@@ -4,7 +4,10 @@ images:
     tag:
       - "0.31.1"
       - "0.41.0"
+      - "0.42.0"
       - "0.43.0"
+      - "0.45.0"
+      - "0.46.0"
     destinations:
       - registry.sighup.io/fury/strimzi/operator
   - name: Strimzi Kafka Image [Fury Kubernetes Kafka]
@@ -20,9 +23,19 @@ images:
       - "0.41.0-kafka-3.6.1"
       - "0.41.0-kafka-3.6.2"
       - "0.41.0-kafka-3.7.0"
+      - "0.42.0-kafka-3.6.0"
+      - "0.42.0-kafka-3.6.1"
+      - "0.42.0-kafka-3.6.2"
+      - "0.42.0-kafka-3.7.0"
+      - "0.42.0-kafka-3.7.1"
       - "0.43.0-kafka-3.7.0"
       - "0.43.0-kafka-3.7.1"
       - "0.43.0-kafka-3.8.0"
+      - "0.45.0-kafka-3.8.0"
+      - "0.45.0-kafka-3.8.1"
+      - "0.45.0-kafka-3.9.0"
+      - "0.46.0-kafka-3.9.0"
+      - "0.46.0-kafka-4.0.0"
     destinations:
       - registry.sighup.io/fury/strimzi/kafka
   - name: Strimzi Kafka Bridge [Fury Kubernetes Kafka]
@@ -44,7 +57,10 @@ images:
     tag:
       - "0.31.1"
       - "0.41.0"
+      - "0.42.0"
       - "0.43.0"
+      - "0.45.0"
+      - "0.46.0"
     destinations:
       - registry.sighup.io/fury/strimzi/kaniko-executor
   - name: Strimzi Maven builder [Fury Kubernetes Kafka]
@@ -52,6 +68,9 @@ images:
     tag:
       - "0.31.1"
       - "0.41.0"
+      - "0.42.0"
       - "0.43.0"
+      - "0.45.0"
+      - "0.46.0"
     destinations:
       - registry.sighup.io/fury/strimzi/maven-builder


### PR DESCRIPTION
This PR adds Strimzi Kafka Operator images for versions `0.42.0`, `0.45.0` and `0.46.0` to the SD Container Image Sync

# Checklist for Testing 🧪

- [x] The images exists and runs without issues

# Details ⚙️
 
- Added version `0.42.0` of Strimzi Operator with all supported Kafka versions (`3.6.0`, `3.6.1`, `3.6.2`, `3.7.0`, `3.7.1`)
- Added version `0.45.0` of Strimzi Operator with all supported Kafka versions (`3.8.0`, `3.8.1`, `3.9.0`)
- Added version `0.46.0` of Strimzi Operator with all supported Kafka versions (`3.9.0`, `4.0.0`)
- Added version `0.42.0`,`0.45.0`,`0.46.0` of Kaniko Executor and Maven Builder 

# Breaking Changes 💔
 
- No breaking changes